### PR TITLE
Misc: add embed for ping command + another basic change

### DIFF
--- a/cogs/misc.py
+++ b/cogs/misc.py
@@ -1,4 +1,5 @@
 import disnake
+from disnake.embeds import Embed
 from disnake.ext import commands
 
 ENABLED = True
@@ -11,7 +12,26 @@ class Misc(commands.Cog):
 
     @commands.slash_command()
     async def ping(self, interaction):
-        await interaction.response.send_message(f"{round(self.bot.latency * 1000)}ms")
+        latency = round(self.bot.latency * 1000)
+        embed_colour = 0x0
+        match latency:
+            case latency if latency < 50:
+                embed_colour = 0x0000FF
+            case latency if latency < 100:
+                embed_colour = 0x00FFFF
+            case latency if latency < 200:
+                embed_colour = 0x00FF00
+            case latency if latency < 300:
+                embed_colour = 0xFFFF00
+            case _:
+                embed_colour = 0xFF0000
+
+        embed_colour = int(embed_colour)
+        embed = Embed(
+            title="Pong!", description=f"Bot latency is {latency}ms", color=embed_colour
+        )
+
+        await interaction.response.send_message(embed=embed)
 
 
 def setup(bot):

--- a/cogs/misc.py
+++ b/cogs/misc.py
@@ -10,13 +10,14 @@ class Misc(commands.Cog):
         print("Misc cog loaded")
 
     @commands.slash_command()
-    async def ping(self, inter: disnake.ApplicationCommandInteraction):
-        await inter.response.send_message(f"{round(self.bot.latency * 1000)}ms")
+    async def ping(self, interaction):
+        await interaction.response.send_message(f"{round(self.bot.latency * 1000)}ms")
 
 
 def setup(bot):
     if ENABLED:
         bot.add_cog(Misc(bot))
+        print("adding cog")
 
 
 def teardown(bot):


### PR DESCRIPTION
## The main change

Ping command is now an embed, with differing colours depending on how good (or bad) the bot ping is.

### Also

The setup def now has a print statement in it, showing that the misc cog is being loaded. This allows the host to see what's being loaded visually.